### PR TITLE
postgres-strict: Add no_implicit_time_zone

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,7 @@ Require AS keyword between expression and column alias.
 ### randomize\_values\_order
 
 Randomize the order in which VALUES produces its values.
+
+### no\_implicit\_time\_zone
+
+Disallow casting directly between date/time/timestamp and timestamptz.

--- a/src/backend/commands/variable.c
+++ b/src/backend/commands/variable.c
@@ -517,6 +517,8 @@ check_postgres_strict_disable(char **newval, void **extra, GucSource source)
 				disabled |= POSTGRES_STRICT_REQUIRE_COLUMN_AS;
 			else if (pg_strcasecmp(tok, "randomize_values_order") == 0)
 				disabled |= POSTGRES_STRICT_RANDOMIZE_VALUES_ORDER;
+			else if (pg_strcasecmp(tok, "no_implicit_time_zone") == 0)
+				disabled |= POSTGRES_STRICT_NO_IMPLICIT_TIME_ZONE;
 			else
 			{
 				GUC_check_errdetail("Unrecognized key word: \"%s\".", tok);

--- a/src/backend/utils/adt/date.c
+++ b/src/backend/utils/adt/date.c
@@ -26,6 +26,7 @@
 #include "libpq/pqformat.h"
 #include "miscadmin.h"
 #include "parser/scansup.h"
+#include "postgres_strict.h"
 #include "utils/array.h"
 #include "utils/builtins.h"
 #include "utils/date.h"
@@ -605,6 +606,14 @@ date2timestamptz(DateADT dateVal)
 			   *tm = &tt;
 	int			tz;
 
+	if (postgres_strict & POSTGRES_STRICT_NO_IMPLICIT_TIME_ZONE)
+	{
+		ereport(postgres_strict_violation_level,
+				(errcode(postgres_strict_violation_sqlstate),
+				 errmsg("date to timestamptz conversion uses session time zone implicitly"),
+				 errhint("Use the AT TIME ZONE construct, or the timezone() function.")));
+	}
+
 	if (DATE_IS_NOBEGIN(dateVal))
 		TIMESTAMP_NOBEGIN(result);
 	else if (DATE_IS_NOEND(dateVal))
@@ -1152,6 +1161,14 @@ timestamptz_date(PG_FUNCTION_ARGS)
 			   *tm = &tt;
 	fsec_t		fsec;
 	int			tz;
+
+	if (postgres_strict & POSTGRES_STRICT_NO_IMPLICIT_TIME_ZONE)
+	{
+		ereport(postgres_strict_violation_level,
+				(errcode(postgres_strict_violation_sqlstate),
+				 errmsg("timestamptz to date conversion uses session time zone implicitly"),
+				 errhint("Use the AT TIME ZONE construct, or the timezone() function.")));
+	}
 
 	if (TIMESTAMP_IS_NOBEGIN(timestamp))
 		DATE_NOBEGIN(result);
@@ -1781,6 +1798,14 @@ timestamptz_time(PG_FUNCTION_ARGS)
 			   *tm = &tt;
 	int			tz;
 	fsec_t		fsec;
+
+	if (postgres_strict & POSTGRES_STRICT_NO_IMPLICIT_TIME_ZONE)
+	{
+		ereport(postgres_strict_violation_level,
+				(errcode(postgres_strict_violation_sqlstate),
+				 errmsg("timestamptz to time conversion uses session time zone implicitly"),
+				 errhint("Use the AT TIME ZONE construct, or the timezone() function.")));
+	}
 
 	if (TIMESTAMP_NOT_FINITE(timestamp))
 		PG_RETURN_NULL();

--- a/src/include/postgres_strict.h
+++ b/src/include/postgres_strict.h
@@ -13,6 +13,7 @@ extern int postgres_strict;
 #define POSTGRES_STRICT_NONE				0
 #define POSTGRES_STRICT_REQUIRE_COLUMN_AS	1
 #define POSTGRES_STRICT_RANDOMIZE_VALUES_ORDER 2
+#define POSTGRES_STRICT_NO_IMPLICIT_TIME_ZONE 4
 #define POSTGRES_STRICT_ALL					((int) ~0)
 
 /* Used in guc.c; must not be equal to any of the codes in utils/elog.h */

--- a/src/test/regress/expected/postgres_strict.out
+++ b/src/test/regress/expected/postgres_strict.out
@@ -110,3 +110,63 @@ SELECT ss.a, ss2.a FROM (VALUES (text 'foo'), ('bar'), ('baz')) ss(a) CROSS JOIN
 (9 rows)
 
 RESET enable_material;
+--
+-- no_implicit_time_zone
+--
+SELECT '2001-02-03'::date::timestamptz;
+ERROR:  date to timestamptz conversion uses session time zone implicitly
+HINT:  Use the AT TIME ZONE construct, or the timezone() function.
+SELECT '2001-02-03 04:05:06'::timestamp::timestamptz;
+ERROR:  timestamp to timestamptz conversion uses session time zone implicitly
+HINT:  Use the AT TIME ZONE construct, or the timezone() function.
+SELECT '2001-02-03 04:05:06+07'::timestamptz::date;
+ERROR:  timestamptz to date conversion uses session time zone implicitly
+HINT:  Use the AT TIME ZONE construct, or the timezone() function.
+SELECT '2001-02-03 04:05:06+07'::timestamptz::time;
+ERROR:  timestamptz to time conversion uses session time zone implicitly
+HINT:  Use the AT TIME ZONE construct, or the timezone() function.
+SELECT '2001-02-03 04:05:06+07'::timestamptz::timestamp;
+ERROR:  timestamptz to timestamp conversion uses session time zone implicitly
+HINT:  Use the AT TIME ZONE construct, or the timezone() function.
+SELECT date_part('hour', '2001-02-03 04:05:06+07'::timestamptz);
+ERROR:  date_part(text, timestamptz) uses session time zone implicitly
+HINT:  Use the AT TIME ZONE construct, or the timezone() function to convert to timestamp before calling date_part().
+SELECT extract(HOUR FROM '2001-02-03 04:05:06+07'::timestamptz);
+ERROR:  date_part(text, timestamptz) uses session time zone implicitly
+HINT:  Use the AT TIME ZONE construct, or the timezone() function to convert to timestamp before calling date_part().
+SELECT date_trunc('hour', '2001-02-03 04:05:06+07'::timestamptz);
+ERROR:  date_trunc(text, timestamptz) uses session time zone implicitly
+HINT:  Use the AT TIME ZONE construct, or the timezone() function to convert to timestamp before calling date_trunc().
+SELECT make_timestamptz(2001, 02, 03, 04, 05, 06);
+ERROR:  timestamp to timestamptz conversion uses session time zone implicitly
+HINT:  Use the AT TIME ZONE construct, or the timezone() function.
+SELECT now() = CURRENT_DATE;
+ERROR:  date to timestamptz conversion uses session time zone implicitly
+HINT:  Use the AT TIME ZONE construct, or the timezone() function.
+SELECT now() = LOCALTIMESTAMP;
+ERROR:  timestamp to timestamptz conversion uses session time zone implicitly
+HINT:  Use the AT TIME ZONE construct, or the timezone() function.
+SELECT date_trunc('day', '2001-02-03 04:05:06+07'::timestamptz AT TIME ZONE 'Asia/Bangkok');
+        date_trunc        
+--------------------------
+ Sat Feb 03 00:00:00 2001
+(1 row)
+
+SELECT make_timestamptz(2001, 02, 03, 04, 05, 06, 'Asia/Bangkok');
+       make_timestamptz       
+------------------------------
+ Fri Feb 02 13:05:06 2001 PST
+(1 row)
+
+SELECT '2001-02-03 04:05:06+07'::timestamptz = '2001-02-03 04:05:06'::timestamp AT TIME ZONE 'Asia/Bangkok';
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT ('2001-02-03 04:05:06+07'::timestamptz AT TIME ZONE 'Asia/Bangkok')::date = '2001-02-03'::date;
+ ?column? 
+----------
+ t
+(1 row)
+

--- a/src/test/regress/sql/postgres_strict.sql
+++ b/src/test/regress/sql/postgres_strict.sql
@@ -41,3 +41,26 @@ SET enable_material TO FALSE;
 SELECT ss.a, ss2.a FROM (VALUES (1), (2), (3)) ss(a) CROSS JOIN (VALUES (4), (5), (6)) ss2(a) ORDER BY ss.a, ss2.a;
 SELECT ss.a, ss2.a FROM (VALUES (text 'foo'), ('bar'), ('baz')) ss(a) CROSS JOIN (VALUES (text 'foo'), ('bar'), ('baz')) ss2(a) ORDER BY ss.a, ss2.a;
 RESET enable_material;
+
+--
+-- no_implicit_time_zone
+--
+SELECT '2001-02-03'::date::timestamptz;
+SELECT '2001-02-03 04:05:06'::timestamp::timestamptz;
+SELECT '2001-02-03 04:05:06+07'::timestamptz::date;
+SELECT '2001-02-03 04:05:06+07'::timestamptz::time;
+SELECT '2001-02-03 04:05:06+07'::timestamptz::timestamp;
+
+SELECT date_part('hour', '2001-02-03 04:05:06+07'::timestamptz);
+SELECT extract(HOUR FROM '2001-02-03 04:05:06+07'::timestamptz);
+SELECT date_trunc('hour', '2001-02-03 04:05:06+07'::timestamptz);
+
+SELECT make_timestamptz(2001, 02, 03, 04, 05, 06);
+
+SELECT now() = CURRENT_DATE;
+SELECT now() = LOCALTIMESTAMP;
+
+SELECT date_trunc('day', '2001-02-03 04:05:06+07'::timestamptz AT TIME ZONE 'Asia/Bangkok');
+SELECT make_timestamptz(2001, 02, 03, 04, 05, 06, 'Asia/Bangkok');
+SELECT '2001-02-03 04:05:06+07'::timestamptz = '2001-02-03 04:05:06'::timestamp AT TIME ZONE 'Asia/Bangkok';
+SELECT ('2001-02-03 04:05:06+07'::timestamptz AT TIME ZONE 'Asia/Bangkok')::date = '2001-02-03'::date;


### PR DESCRIPTION
Some conversions to and from timestamptz often hides bugs as the result depend on the current session time zone.

Disallow such conversions in favour of the AT TIME ZONE construct or the timezone() function.

As suggested in #5